### PR TITLE
[halium-5.1] proprietary-files.txt: Remove APKs and JARs

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -59,9 +59,6 @@ vendor/lib/libWVStreamControlAPI_L1.so
 vendor/lib/mediadrm/libwvdrmengine.so
 
 # GPS
--app/com.qualcomm.location/com.qualcomm.location.apk
--app/com.qualcomm.services.location/com.qualcomm.services.location.apk
--app/MotGeoFenceSvc/MotGeoFenceSvc.apk
 bin/location-mq
 bin/xtwifi-client
 bin/xtwifi-inet-agent
@@ -159,7 +156,6 @@ vendor/lib/libqmiservices.so
 vendor/lib/libsmemlog.so
 
 # Radio
--app/qcrilmsgtunnel/qcrilmsgtunnel.apk
 bin/netmgrd
 bin/qmuxd
 bin/radish
@@ -169,8 +165,6 @@ bin/rmt_storage
 bin/qmi_motext_hook
 etc/permissions/qcnvitems.xml
 etc/permissions/qcrilhook.xml
--framework/qcnvitems.jar
--framework/qcrilhook.jar
 lib/libadropbox.so
 lib/libmdmcutback.so
 lib/libmdmdetect.so
@@ -190,7 +184,6 @@ vendor/lib/libthermalclient.so
 vendor/lib/libthermalioctl.so
 
 # Time services
--app/TimeService/TimeService.apk
 bin/time_daemon
 vendor/lib/libtime_genoff.so
 vendor/lib/libTimeService.so


### PR DESCRIPTION
This will fix the sign-apk bugs since halium-devices will regenerate the
makefiles of the vendor repository.